### PR TITLE
Add reboot to install mode command

### DIFF
--- a/sanity/agent/agent.py
+++ b/sanity/agent/agent.py
@@ -25,8 +25,18 @@ def start(plan, con, sched=None):
                 if "initial_login" in stage.keys():
                     print(gen_head_string("init login"))
                     init_mode_login(
-                        con, stage["initial_login"].get("timeout", 600)
+                        con,
+                        stage["initial_login"].get("method"),
+                        stage["initial_login"].get("timeout", 600),
                     )
+                elif "reboot_install" in stage.keys():
+                    con.write_con_no_wait("sudo snap reboot --install")
+                    init_mode_login(
+                        con,
+                        stage["reboot_install"].get("method"),
+                        stage["reboot_install"].get("timeout", 600),
+                    )
+
                 elif "deploy" in stage.keys():
                     print(gen_head_string("deploy procedure"))
                     if (

--- a/sanity/launcher/parser.py
+++ b/sanity/launcher/parser.py
@@ -63,14 +63,7 @@ LAUNCHER_SCHEMA = {
                                             "seed_override_lk",
                                         ],
                                     },
-                                    "method": {
-                                        "type": "string",
-                                        "enum": [
-                                            "cloud-init",
-                                            "console-conf",
-                                            "system-user",
-                                        ],
-                                    },
+                                    "method": {"$ref": "#/$defs/method"},
                                     "timeout": {
                                         "type": "integer",
                                         "default": 600,
@@ -100,11 +93,24 @@ LAUNCHER_SCHEMA = {
                             "initial_login": {
                                 "type": "object",
                                 "properties": {
+                                    "method": {"$ref": "#/$defs/method"},
                                     "timeout": {
                                         "type": "integer",
                                         "default": 600,
-                                    }
+                                    },
                                 },
+                                "required": ["method"],
+                            },
+                            "reboot_install": {
+                                "type": "object",
+                                "properties": {
+                                    "method": {"$ref": "#/$defs/method"},
+                                    "timeout": {
+                                        "type": "integer",
+                                        "default": 600,
+                                    },
+                                },
+                                "required": ["method"],
                             },
                             "sys_commands": {
                                 "type": "array",
@@ -150,6 +156,14 @@ LAUNCHER_SCHEMA = {
         "mail_format": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9.]+@[a-zA-Z0-9.]+$",
+        },
+        "method": {
+            "type": "string",
+            "enum": [
+                "cloud-init",
+                "console-conf",
+                "system-user",
+            ],
         },
     },
 }

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -58,7 +58,16 @@ class LauncherParserTests(unittest.TestCase):
                 },
                 "login",
                 {
-                    "initial_login": {"timeout": 300}
+                    "initial_login": {
+                        "method": "cloud-init",
+                        "timeout": 300
+                    }
+                },
+                {
+                    "reboot_install": {
+                        "method": "cloud-init",
+                        "timeout": 300
+                    }
                 },
                 {"sys_commands": [
                     "ls",


### PR DESCRIPTION
impact:
    sanity/agent/agent.py
    sanity/launcher/parser.py

description:
    add reboot to install mode command, we are not using EOF to do this
    due to it could casue hang as reboot did.

test:
    N/A