### PR TITLE
Use model assertion to find gadget snap

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest-mock
 commands =
     {envbindir}/pip3 install .
-    {envbindir}/python -m black -l 79 --check sanity
+    {envbindir}/python -m black -l 79 --check sanity --diff --verbose
     {envbindir}/python -m flake8 sanity
     #{envbindir}/python -m pylint sanity
     {envbindir}/python -m pytest --doctest-modules --cov=sanity


### PR DESCRIPTION
On some devices, the name of gadget snap doesn't contain *gadget*. So it's better to find the gadget name via model assertion.