### PR TITLE
Add uuu case for support download mode that set by DIP switch

### DIFF
--- a/sanity/agent/deploy.py
+++ b/sanity/agent/deploy.py
@@ -182,6 +182,18 @@ def boot_assets_update(ADDR):
 def deploy(con, method, user_init, update_boot_assets, timeout=600):
     match method:
         case "uuu":
+            if syscmd("sudo uuu uc.lst") != 0:
+                mail.send_mail(
+                    FAILED,
+                    (
+                        f"{dev_data.project} auto sanity was failed, "
+                        "deploy failed."
+                    ),
+                )
+                return FAILED
+            return
+
+        case "uuu_bootloader":
             while True:
                 mesg = con.read_con()
                 if mesg.find("Fastboot:") != -1:
@@ -199,6 +211,7 @@ def deploy(con, method, user_init, update_boot_assets, timeout=600):
                     con.write_con_no_wait("\x03")  # ctrl+c
                     con.write_con_no_wait("run bootcmd")
                     break
+
         case "seed_override":
             login(con)
             ADDR = get_ip(con)

--- a/sanity/launcher/parser.py
+++ b/sanity/launcher/parser.py
@@ -59,6 +59,7 @@ LAUNCHER_SCHEMA = {
                                         "type": "string",
                                         "enum": [
                                             "uuu",
+                                            "uuu_bootloader",
                                             "seed_override",
                                             "seed_override_lk",
                                         ],


### PR DESCRIPTION
impact:
    sanity/agent/deploy.py

description:
    Due to downalod set by DIP switch need extra action between flash and initial boot,
    and the extra actions are depend on platform. So We separate flash and initial boot then
    User can customize the actions in the between.

test:
    N/A