### PR TITLE
Increase the timeout for flasing Tillamook image to 1200

### DIFF
--- a/sanity/agent/deploy.py
+++ b/sanity/agent/deploy.py
@@ -234,7 +234,8 @@ def deploy(con, method, user_init, update_boot_assets, timeout=600):
                 syscmd(
                     f"set -x; cd {flash_script_dir} && "
                     f"sudo imx6-img-flash-tool.flash ../{image_name} "
-                    "../u-boot-500.imx"
+                    "../u-boot-500.imx",
+                    timeout=1200,
                 )
                 != 0
             ):


### PR DESCRIPTION
The default timeout is 300, and it take more than 15 mins to flash image for Tillamook device