### PR TITLE
Return command failed message while command failed or timeout

### DIFF
--- a/sanity/agent/cmd.py
+++ b/sanity/agent/cmd.py
@@ -16,9 +16,9 @@ def syscmd(message="", timeout=300):
         )
     except Subprocess.CalledProcessError:
         print(f"command {message} failed")
-        return FAILED, None
+        return FAILED, f"command {message} failed"
     except Subprocess.TimeoutExpired:
         print(f"command {message} timeout, timeout={timeout}")
-        return FAILED, None
+        return FAILED, f"command {message} timeout"
 
     return SUCCESS, result


### PR DESCRIPTION
impact:
    sanity/agent/cmd.py

description:
    If return None, the second variable of caller is considered not been assgined.
    So, we return error message.

test:
    N/A