### PR TITLE
Give report variable an initial to avoid local variable referenced be…

### DIFF
--- a/sanity/agent/checkbox.py
+++ b/sanity/agent/checkbox.py
@@ -57,6 +57,8 @@ def run_checkbox(con, cbox, runner_cfg, secure_id, desc):
                 )
                 syscmd(f"mv report.tar.xz {report_name}")
                 print(upload_command)
+
+                report = "failed to submit report"
                 status, result = syscmd(upload_command)
                 if status == 0:
                     report = re.search(


### PR DESCRIPTION
…fore assignment

impact:
    sanity/agent/checkbox.py

description:
    Give report variable an initial to avoid local variable referenced before assignment

test:
    N/A