### PR TITLE
Print out the C3 report url

### DIFF
--- a/sanity/agent/checkbox.py
+++ b/sanity/agent/checkbox.py
@@ -65,6 +65,7 @@ def run_checkbox(con, cbox, runner_cfg, secure_id, desc):
                         r"(?P<url>https?://certification.canonical.com[^\s]+)",
                         (result.stdout).decode("utf-8"),
                     ).group("url")
+                print(f"report: {report}")
                 print("auto sanity is finished")
                 return {
                     "code": SUCCESS,


### PR DESCRIPTION
impact:
    sanity/agent/checkbox.py

description:
    print out the C3 report url, this info would be used
    by channel monitor tool

test:
    C3 report url show up