### PR TITLE
Workaround for checkbox cli

### DIFF
--- a/sanity/agent/checkbox.py
+++ b/sanity/agent/checkbox.py
@@ -50,7 +50,8 @@ def run_checkbox(con, runner_cfg, secure_id, desc):
                 ).group("url")
             except AttributeError:
                 print("report url is not found")
-
+        else:
+            report = "failed to submit report"
         print(f"report: {report}")
         print("auto sanity is finished")
         return {

--- a/sanity/agent/checkbox.py
+++ b/sanity/agent/checkbox.py
@@ -41,7 +41,6 @@ def run_checkbox(con, runner_cfg, secure_id, desc):
         print(upload_command)
 
         status, result = syscmd(upload_command)
-        report = "failed to submit report"
         if status == 0:
             try:
                 report = re.search(

--- a/sanity/agent/checkbox.py
+++ b/sanity/agent/checkbox.py
@@ -1,5 +1,6 @@
 """For handle checkbox task"""
 
+import os
 import time
 import re
 from sanity.agent.cmd import syscmd
@@ -27,13 +28,12 @@ def run_checkbox(con, runner_cfg, secure_id, desc):
             f"target device connection timeout.",
         }
 
-    status, result = syscmd(
-        f"sudo checkbox.checkbox-cli control {addr} {runner_cfg}", 43200
-    )
+    syscmd(f"sudo checkbox.checkbox-cli control {addr} {runner_cfg}", 43200)
 
     mail_t = time.strftime("%Y/%m/%d %H:%M")
 
-    if status == 0:
+    # if status == 0:
+    if os.path.exists("report.tar.xz"):
         upload_command = (
             f'checkbox.checkbox-cli submit -m "{desc}" '
             f"{secure_id} report.tar.xz"
@@ -41,6 +41,7 @@ def run_checkbox(con, runner_cfg, secure_id, desc):
         print(upload_command)
 
         status, result = syscmd(upload_command)
+        report = "failed to submit report"
         if status == 0:
             try:
                 report = re.search(
@@ -48,7 +49,7 @@ def run_checkbox(con, runner_cfg, secure_id, desc):
                     result,
                 ).group("url")
             except AttributeError:
-                report = "failed to submit report"
+                print("report url is not found")
 
         print(f"report: {report}")
         print("auto sanity is finished")


### PR DESCRIPTION
impact:
    sanity/agent/checkbox.py

description:
    current checkbox remote returncode is always 1 not matter success or fail
    So our workaround is not using returncode but check report file

test:
    N/A