### PR TITLE
Support provision tool(genio-flash) for MediaTek devices

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Program your own tplan yaml
             password: target device user password
             serial_console:
                 port: /dev/ttyUSBxxx
-                baud_rate: baud rate, support[115200, 9600]
+                baud_rate: baud rate, support[115200, 9600, 921600]
             network: target device interface
             extra-recepients: ["yourmail@mail.com"]
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pyserial",
     "schedule",
     "wrapt_timeout_decorator",
+    "whl",
 ]
 
 dynamic = ["version"]

--- a/sanity/agent/agent.py
+++ b/sanity/agent/agent.py
@@ -75,6 +75,7 @@ def start(plan, con, sched=None):
                         con,
                         stage["deploy"].get("utility"),
                         stage["deploy"].get("method"),
+                        stage["deploy"].get("extra_provision_tool_args"),
                         stage["deploy"].get("update_boot_assets", False),
                         stage["deploy"].get("timeout", 600),
                     )

--- a/sanity/agent/deploy.py
+++ b/sanity/agent/deploy.py
@@ -180,9 +180,6 @@ def deploy(
     match method:
         case "genio_flash":
             # Assuming the host is >= 22.04
-            syscmd(
-                "set -x; sudo apt-get install -y python3-pip python3-pip-whl"
-            )
             gitlab_url = (
                 "git+https://gitlab.com/mediatek/aiot/bsp/"
                 + "genio-tools.git#egg=genio-tools"

--- a/sanity/launcher/parser.py
+++ b/sanity/launcher/parser.py
@@ -21,7 +21,7 @@ LAUNCHER_SCHEMA = {
                         "port": {"type": "string"},
                         "baud_rate": {
                             "type": "integer",
-                            "enum": [115200, 9600],
+                            "enum": [115200, 9600, 921600],
                             "default": 115200,
                         },
                     },
@@ -60,6 +60,7 @@ LAUNCHER_SCHEMA = {
                                     "utility": {
                                         "type": "string",
                                         "enum": [
+                                            "genio_flash",
                                             "utp_com",
                                             "uuu",
                                             "uuu_bootloader",
@@ -69,6 +70,9 @@ LAUNCHER_SCHEMA = {
                                         ],
                                     },
                                     "method": {"$ref": "#/$defs/method"},
+                                    "extra_provision_tool_args": {
+                                        "type": "string"
+                                    },
                                     "timeout": {
                                         "type": "integer",
                                         "default": 600,


### PR DESCRIPTION
* Add baudrate 921600 for MediaTek devices
* Disable Pylint R0913 to allow more args in the function. By default Pylint only allows 5 argument in the function
* Add a new key(extra_provision_tool_args) for user to specify additional arguments consumed by provision tool. For example we can use something like "-e list_dtbo=aaaa.dtbo bbbb.dtbo" with MediaTek devices to make it load different dtbo when doing test.