### PR TITLE
Check refresh.hold status before setting

### DIFF
--- a/sanity/agent/deploy.py
+++ b/sanity/agent/deploy.py
@@ -369,6 +369,7 @@ def login(con):
 
         elif mesg.find(DevData.device_uname + "@") != -1:
             con.write_con(
+                "snap refresh --time | grep hold || "
                 'sudo snap set system refresh.hold="$(date --date=tomorrow'
                 ' +%Y-%m-%dT%H:%M:%S%:z)"'
             )


### PR DESCRIPTION
On some devices, they have default `refresh.hold` set, so we don't need to override them.

For instance:
**Without refresh.hold**
```
$ snap refresh --time
timer: 00:00~24:00/4
last: today at 08:31 CST
next: today at 17:05 CST
```

**With refresh.hold**
```
$ snap refresh --time
timer: 00:00~24:00/4
last: n/a
hold: forever
next: today at 01:38 UTC (but held)
```
or
```
$ snap refresh --time
timer: 00:00~24:00/4
last: n/a
hold: tomorrow at 00:53 UTC
next: today at 00:53 UTC (but held)
```