### PR TITLE
Refine SSH connection implementation

### DIFF
--- a/sanity/agent/ssh.py
+++ b/sanity/agent/ssh.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from dataclasses import dataclass
+from socket import error as SocketError
 import paramiko
 
 
@@ -47,7 +48,7 @@ class SSHConnection:
             self.close()
 
         self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.set_missing_host_key_policy(paramiko.WarningPolicy())
 
         waiting = time.time() + self.info.timeout
         while True:
@@ -59,9 +60,12 @@ class SSHConnection:
                     self.info.passwd,
                 )
             except (
-                paramiko.ssh_exception.NoValidConnectionsError,
+                paramiko.ssh_exception.BadHostKeyException,
                 paramiko.ssh_exception.AuthenticationException,
+                paramiko.ssh_exception.UnableToAuthenticate,
+                paramiko.ssh_exception.NoValidConnectionsError,
                 paramiko.ssh_exception.SSHException,
+                SocketError,
             ) as e:
                 print(e)
                 if time.time() > waiting:


### PR DESCRIPTION
1. Add SocketError exception to handle Ubuntu Core install mode case
 - Ubuntu Core install mode may make SSH connection to get socket error when it auto-reboot
2. Change the SSH host key adding policy from auto to warning. Because the Ubuntu Core install and run mode makes the SSH client confused with the same host, but different SSH host key.
 - Auto policy adding host key when the key doesn't exist in the known list. But it skips to add the new key when an old key already added in the known list.
 - Warning policy show warning and accepts any unknown host key. Under the close network environment of cert-lab, it's acceptable.